### PR TITLE
fix: avoid using a too simple regexp to detect deppness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,6 @@
         <groupId>org.jahia.modules</groupId>
         <version>8.0.0.0</version>
     </parent>
-    <groupId>org.jahia.modules</groupId>
     <artifactId>directive-filter</artifactId>
     <name>Directive Filter</name>
     <version>2.2.0-SNAPSHOT</version>
@@ -57,8 +56,40 @@
         </repository>
     </repositories>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.8.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.8.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.6.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>4.6.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/src/main/java/org/jahia/modules/directivefilter/QueryFilter.java
+++ b/src/main/java/org/jahia/modules/directivefilter/QueryFilter.java
@@ -21,7 +21,7 @@ import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.regex.Matcher;
+import java.security.InvalidParameterException;
 import java.util.regex.Pattern;
 
 import static java.util.stream.Collectors.joining;
@@ -30,12 +30,11 @@ import static java.util.stream.Collectors.joining;
 public class QueryFilter implements Filter {
 
     // Detect strings such as @lala@lala@lala... and with space(s) in between @lala @lala
-    private Pattern regex = Pattern.compile("(@[^ @]+[ ]*){10}");
-    private Pattern deep = Pattern.compile("\\{");
+    private static final Pattern DIRECTIVE_REGEX = Pattern.compile("(@[^ @]+[\\s]*){10}");
 
     @Override
-    public void init(FilterConfig filterConfig) throws ServletException {
-
+    public void init(FilterConfig filterConfig)  {
+        // Initialization logic if needed
     }
 
     @Override
@@ -44,7 +43,7 @@ public class QueryFilter implements Filter {
             MultiReadRequestWrapper r = new MultiReadRequestWrapper((HttpServletRequest) servletRequest);
             String query = r.getReader().lines().collect(joining(" "));
 
-            if (regex.matcher(query).find()) {
+            if (DIRECTIVE_REGEX.matcher(query).find()) {
                 HttpServletResponse resp = (HttpServletResponse) servletResponse;
                 resp.setContentType("application/json");
                 resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
@@ -53,20 +52,13 @@ public class QueryFilter implements Filter {
                 return;
             }
 
-            Matcher matcher = deep.matcher(query);
-            int deepLevel = 0;
-            while (matcher.find()) {
-                deepLevel++;
-                if(deepLevel > 250) {
-                    break;
-                }
-            }
-
-            if(deepLevel > 250) {
+            try {
+                checkMaxDepth(query);
+            } catch (InvalidParameterException e) {
                 HttpServletResponse resp = (HttpServletResponse) servletResponse;
                 resp.setContentType("application/json");
                 resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-                resp.getWriter().println("{\"message\": \"You can only use up to 250 depths\"}");
+                resp.getWriter().println("{\"message\": \"" + e.getMessage() + "\"}");
                 resp.getWriter().flush();
                 return;
             }
@@ -79,6 +71,35 @@ public class QueryFilter implements Filter {
 
     @Override
     public void destroy() {
-
+        // Cleanup logic if needed
     }
+
+    private void checkMaxDepth(String input) throws InvalidParameterException {
+        final int maxAllowedDepth = 250;
+        int maxDepth = 0;
+        int currentDepth = 0;
+        char[] chars = input.toCharArray();
+
+        for (char c : chars) {
+            if (c == '{') {
+                currentDepth++;
+                if (currentDepth > maxDepth) {
+                    maxDepth = currentDepth;
+                }
+            } else if (c == '}') {
+                currentDepth--;
+                if (currentDepth < 0) {
+                    throw new InvalidParameterException("Unmatched braces in input string");
+                }
+            }
+            if (currentDepth > maxAllowedDepth) {
+                throw new InvalidParameterException("Maximum allowed depth exceeded: " + maxAllowedDepth);
+            }
+        }
+
+        if (currentDepth != 0) {
+            throw new InvalidParameterException("Unmatched braces in input string");
+        }
+    }
+
 }

--- a/src/test/java/org/jahia/modules/directivefilter/QueryFilterTest.java
+++ b/src/test/java/org/jahia/modules/directivefilter/QueryFilterTest.java
@@ -1,0 +1,204 @@
+package org.jahia.modules.directivefilter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.*;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class QueryFilterTest {
+
+    private QueryFilter queryFilter;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    private StringWriter responseWriter;
+
+    @BeforeEach void setUp() throws IOException {
+        queryFilter = new QueryFilter();
+
+        // Setup response writer
+        responseWriter = new StringWriter();
+        PrintWriter writer = new PrintWriter(responseWriter);
+        when(response.getWriter()).thenReturn(writer);
+    }
+
+    private void setupRequestWithBody(String body) throws IOException {
+        InputStream is = new ByteArrayInputStream(body.getBytes());
+        when(request.getInputStream()).thenReturn(new ServletInputStream() {
+            @Override
+            public int read() throws IOException {
+                return is.read();
+            }
+        });
+    }
+
+    @Test void testLessThan10Directives() throws IOException, ServletException {
+        // 9 directives
+        String input = "@test1 @test2 @test3 @test4 @test5 @test6 @test7 @test8 @test9";
+        setupRequestWithBody(input);
+
+        queryFilter.doFilter(request, response, filterChain);
+
+        // Filter chain should proceed since request is valid
+        verify(filterChain).doFilter(any(), eq(response));
+        verify(response, never()).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+
+        // Test with mixed spaces
+        String inputMixed = "@test1@test2 @test3@test4 @test5 @test6@test7 @test8 @test9";
+        setupRequestWithBody(inputMixed);
+
+        queryFilter.doFilter(request, response, filterChain);
+        verify(filterChain, times(2)).doFilter(any(), eq(response));
+    }
+
+    @Test void testMoreThan10Directives() throws IOException, ServletException {
+        // 11 directives
+        String input = "@test1 @test2 @test3 @test4 @test5 @test6 @test7 @test8 @test9 @test10 @test11";
+        setupRequestWithBody(input);
+
+        queryFilter.doFilter(request, response, filterChain);
+
+        // Should return error response
+        verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        verify(response).setContentType("application/json");
+        verify(filterChain, never()).doFilter(any(), any());
+        assertTrue(responseWriter.toString().contains("up to 10 consecutive directives"));
+
+        // Test with mixed spaces
+        reset(response, filterChain);
+        responseWriter = new StringWriter();
+        when(response.getWriter()).thenReturn(new PrintWriter(responseWriter));
+
+        String inputMixed = "@test1@test2@test3 @test4 @test5@test6 @test7@test8 @test9 @test10@test11";
+        setupRequestWithBody(inputMixed);
+
+        queryFilter.doFilter(request, response, filterChain);
+        verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+    @Test void testManyNonNestedBraces() throws IOException, ServletException {
+        // 300 non-nested {} pairs
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 300; i++) {
+            sb.append("{}");
+        }
+        String input = sb.toString();
+        setupRequestWithBody(input);
+
+        queryFilter.doFilter(request, response, filterChain);
+
+        // Filter chain should proceed since request is valid
+        verify(filterChain).doFilter(any(), eq(response));
+        verify(response, never()).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+    @Test void testExcessivelyNestedBraces() throws IOException, ServletException {
+        // Creates 251 nesting levels
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 251; i++) {
+            sb.append("{");
+        }
+        for (int i = 0; i < 251; i++) {
+            sb.append("}");
+        }
+        String input = sb.toString();
+        setupRequestWithBody(input);
+
+        queryFilter.doFilter(request, response, filterChain);
+
+        // Should return error response
+        verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        verify(response).setContentType("application/json");
+        verify(filterChain, never()).doFilter(any(), any());
+        assertTrue(responseWriter.toString().contains("Maximum allowed depth exceeded"));
+    }
+
+    @Test void testMaxAllowedDepth() throws IOException, ServletException {
+        // Exactly 250 nesting levels
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 250; i++) {
+            sb.append("{");
+        }
+        for (int i = 0; i < 250; i++) {
+            sb.append("}");
+        }
+        String input = sb.toString();
+        setupRequestWithBody(input);
+
+        queryFilter.doFilter(request, response, filterChain);
+
+        // Filter chain should proceed since request is valid
+        verify(filterChain).doFilter(any(), eq(response));
+        verify(response, never()).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+    @Test void testMoreOpenBracesThanCloseBraces() throws IOException, ServletException {
+        String input = "{{{}";  // 3 opening braces, 1 closing brace
+        setupRequestWithBody(input);
+
+        queryFilter.doFilter(request, response, filterChain);
+
+        // Should return error response
+        verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        verify(response).setContentType("application/json");
+        verify(filterChain, never()).doFilter(any(), any());
+        assertTrue(responseWriter.toString().contains("Unmatched braces"));
+    }
+
+    @Test void testMoreCloseBracesThanOpenBraces() throws IOException, ServletException {
+        String input = "{}}";  // 1 opening brace, 2 closing braces
+        setupRequestWithBody(input);
+
+        queryFilter.doFilter(request, response, filterChain);
+
+        // Should return error response
+        verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        verify(response).setContentType("application/json");
+        verify(filterChain, never()).doFilter(any(), any());
+        assertTrue(responseWriter.toString().contains("Unmatched braces"));
+    }
+
+    @Test void testEmptyInput() throws IOException, ServletException {
+        String input = "";
+        setupRequestWithBody(input);
+
+        queryFilter.doFilter(request, response, filterChain);
+
+        // Filter chain should proceed since request is valid
+        verify(filterChain).doFilter(any(), eq(response));
+        verify(response, never()).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+    @Test void testComplexQueryWithMixedDirectivesAndBraces() throws IOException, ServletException {
+        String input = "query { @directive1 @directive2 field { nested { @directive3 value } } @directive4 }";
+        setupRequestWithBody(input);
+
+        queryFilter.doFilter(request, response, filterChain);
+
+        // Filter chain should proceed since request is valid
+        verify(filterChain).doFilter(any(), eq(response));
+        verify(response, never()).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    }
+}


### PR DESCRIPTION
### Description
False positives about deepness was possible with previous implementation. The goal is to fix it with a stronger algorithm and some JUnit Tests.

### Checklist
#### Source code
- [X] I've shared and documented any breaking change
- [X] I've reviewed and updated the jahia-depends

#### Tests
- [X] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
